### PR TITLE
feat: add project name configuration

### DIFF
--- a/docs/llm/plans/2026/04/10-add-project-name.md
+++ b/docs/llm/plans/2026/04/10-add-project-name.md
@@ -1,0 +1,96 @@
+# Implementation Plan - Add Project Name Configuration
+
+Add a new configuration "project name" to `DpsConfig` in both Rust and TypeScript implementations.
+
+## Proposed Changes
+
+### Rust Implementation (`src/lib.rs`)
+
+1. **Update `DpsConfig` struct**:
+   ```rust
+   pub struct DpsConfig {
+     // Global properties
+     project_name: Option<String>,
+     domain: Option<String>,
+     // ...
+   }
+   ```
+
+2. **Update `DpsConfig::new()`**:
+   ```rust
+   pub fn new() -> Self {
+     Self {
+       project_name: load_env_string("DPS_PROJECT_NAME"),
+       domain: load_env_string("DPS_DOMAIN"),
+       // ...
+     }
+   }
+   ```
+
+3. **Add getter and setter**:
+   ```rust
+   /// Returns the configured project name or the default `"My Project"`.
+   ///
+   /// Env var: `DPS_PROJECT_NAME`
+   pub fn get_project_name(&self) -> String {
+     self
+       .project_name
+       .clone()
+       .unwrap_or_else(|| "My Project".to_string())
+   }
+
+   /// Set the project name value (overrides any environment-provided value).
+   pub fn set_project_name(&mut self, value: &str) {
+     self.project_name = Some(value.to_string());
+   }
+   ```
+
+4. **Update tests**:
+   - Update `test_default_values` and `test_setters`.
+   - Add `test_project_name` to verify `DPS_PROJECT_NAME` env var.
+
+### TypeScript Implementation (`src/index.ts`)
+
+1. **Update `DpsConfig` class properties**:
+   ```typescript
+   export class DpsConfig {
+     private projectName?: string;
+     private domain?: string;
+     // ...
+   }
+   ```
+
+2. **Update constructor**:
+   ```typescript
+   constructor(envPrefix: string = "") {
+     this.projectName = this.loadEnvString(envPrefix, "DPS_PROJECT_NAME");
+     this.domain = this.loadEnvString(envPrefix, "DPS_DOMAIN");
+     // ...
+   }
+   ```
+
+3. **Add getter and setter**:
+   ```typescript
+   getProjectName(): string {
+     return this.projectName ?? "My Project";
+   }
+
+   setProjectName(value: string) {
+     this.projectName = value;
+   }
+   ```
+
+### Tests (`src/index.test.ts`)
+
+1. **Update existing tests**:
+   - Update "should have correct default values" to check `getProjectName()`.
+   - Update "should work with setters" to check `setProjectName()`.
+
+2. **Add new test**:
+   - Add test case for loading `DPS_PROJECT_NAME` from environment variables.
+
+## Verification Plan
+
+1. Run `cargo test` for Rust implementation.
+2. Run `bun test` for TypeScript implementation.
+3. Run `cargo clippy --allow-dirty --fix && cargo fmt` for linting and formatting.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,6 +12,7 @@ describe("DpsConfig", () => {
 
   it("should have correct default values", () => {
     const config = new DpsConfig();
+    expect(config.getProjectName()).toBe("My Project");
     expect(config.getDomain()).toBe("dps.localhost");
     expect(config.getApiPath()).toBe("api");
     expect(config.getDevelopmentMode()).toBe(false);
@@ -31,12 +32,14 @@ describe("DpsConfig", () => {
 
   it("should work with setters", () => {
     const config = new DpsConfig();
+    config.setProjectName("Custom Project");
     config.setDomain("example.com");
     config.setApiPath("v1");
     config.setDevelopmentMode(true);
     config.setAuthApiPort(3000);
     config.setAuthApiSessionSecret("s3cr3t");
 
+    expect(config.getProjectName()).toBe("Custom Project");
     expect(config.getDomain()).toBe("example.com");
     expect(config.getApiPath()).toBe("v1");
     expect(config.getDevelopmentMode()).toBe(true);
@@ -115,6 +118,12 @@ describe("DpsConfig", () => {
     process.env.DPS_API_PATH = "api/v2";
     const config = new DpsConfig();
     expect(config.getApiPath()).toBe("api/v2");
+  });
+
+  it("should load project name from env", () => {
+    process.env.DPS_PROJECT_NAME = "Env Project";
+    const config = new DpsConfig();
+    expect(config.getProjectName()).toBe("Env Project");
   });
 
   it("should support envPrefix", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
  * It focuses on optional values, sensible defaults, and environment variable loading.
  */
 export class DpsConfig {
+  private projectName?: string;
   private domain?: string;
   private apiPath?: string;
   private developmentMode?: boolean;
@@ -28,6 +29,7 @@ export class DpsConfig {
    * @param envPrefix Optional prefix for environment variables (e.g. "VITE_" for Vite support).
    */
   constructor(envPrefix: string = "") {
+    this.projectName = this.loadEnvString(envPrefix, "DPS_PROJECT_NAME");
     this.domain = this.loadEnvString(envPrefix, "DPS_DOMAIN");
     this.apiPath = this.loadEnvString(envPrefix, "DPS_API_PATH");
     this.developmentMode = this.loadEnvBool(envPrefix, "DPS_DEVELOPMENT_MODE");
@@ -49,6 +51,14 @@ export class DpsConfig {
   // --------------------
   // Global getters/setters
   // --------------------
+
+  getProjectName(): string {
+    return this.projectName ?? "My Project";
+  }
+
+  setProjectName(value: string) {
+    this.projectName = value;
+  }
 
   getDomain(): string {
     return this.domain ?? "dps.localhost";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ use std::env;
 /// crates should validate values where required.
 pub struct DpsConfig {
   // Global properties
+  project_name: Option<String>,
   domain: Option<String>,
   api_path: Option<String>,
   development_mode: Option<bool>,
@@ -81,6 +82,7 @@ impl DpsConfig {
   /// - `DPS_AUTH_API_SESSION_TTL_SECONDS`
   pub fn new() -> Self {
     Self {
+      project_name: load_env_string("DPS_PROJECT_NAME"),
       domain: load_env_string("DPS_DOMAIN"),
       api_path: load_env_string("DPS_API_PATH"),
       development_mode: load_env_bool("DPS_DEVELOPMENT_MODE"),
@@ -106,6 +108,21 @@ impl DpsConfig {
   // --------------------
   // Global getters/setters
   // --------------------
+
+  /// Returns the configured project name or the default `"My Project"`.
+  ///
+  /// Env var: `DPS_PROJECT_NAME`
+  pub fn get_project_name(&self) -> String {
+    self
+      .project_name
+      .clone()
+      .unwrap_or_else(|| "My Project".to_string())
+  }
+
+  /// Set the project name value (overrides any environment-provided value).
+  pub fn set_project_name(&mut self, value: &str) {
+    self.project_name = Some(value.to_string());
+  }
 
   /// Returns the configured domain or the default `"dps.localhost"`.
   ///
@@ -395,6 +412,7 @@ mod tests {
   #[serial]
   fn test_default_values() {
     let config = DpsConfig::new();
+    assert_eq!(config.get_project_name(), "My Project");
     assert_eq!(config.get_domain(), "dps.localhost");
     assert_eq!(config.get_api_path(), "api");
     assert!(!config.get_development_mode());
@@ -424,12 +442,14 @@ mod tests {
   #[test]
   fn test_setters() {
     let mut config = DpsConfig::new();
+    config.set_project_name("Custom Project");
     config.set_domain("example.com");
     config.set_api_path("v1");
     config.set_development_mode(true);
     config.set_auth_api_port(Some(3000));
     config.set_auth_api_session_secret(Some("s3cr3t"));
 
+    assert_eq!(config.get_project_name(), "Custom Project");
     assert_eq!(config.get_domain(), "example.com");
     assert_eq!(config.get_api_path(), "v1");
     assert!(config.get_development_mode());
@@ -648,6 +668,22 @@ mod tests {
     let c2 = DpsConfig::new();
     assert_eq!(c2.get_auth_api_session_ttl_seconds(), 1800);
     std::env::remove_var("DPS_AUTH_API_SESSION_TTL_SECONDS");
+  }
+
+  #[test]
+  #[serial]
+  fn test_project_name() {
+    // Test default and setter
+    let mut c = DpsConfig::new();
+    assert_eq!(c.get_project_name(), "My Project");
+    c.set_project_name("New Name");
+    assert_eq!(c.get_project_name(), "New Name");
+
+    // Test env var loading
+    std::env::set_var("DPS_PROJECT_NAME", "Env Project");
+    let c2 = DpsConfig::new();
+    assert_eq!(c2.get_project_name(), "Env Project");
+    std::env::remove_var("DPS_PROJECT_NAME");
   }
 
   #[test]


### PR DESCRIPTION
This PR adds a new "project name" configuration property to `DpsConfig` in both Rust (`src/lib.rs`) and TypeScript (`src/index.ts`).

Changes:
- Added `project_name` (Rust) and `projectName` (TypeScript) properties to `DpsConfig`.
- Updated constructors to load `DPS_PROJECT_NAME` from environment variables.
- Implemented `get_project_name` / `getProjectName` with default "My Project".
- Implemented `set_project_name` / `setProjectName` setters.
- Added unit tests in both languages verifying default values, manual setting, and environment variable loading.
- Added an implementation plan at `docs/llm/plans/2026/04/10-add-project-name.md`.


---
*PR created automatically by Jules for task [17669249648952478835](https://jules.google.com/task/17669249648952478835) started by @pauldps*