### PR TITLE
feat: update README and refactor TypeScript env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ fn main() {
 ```typescript
 import { DpsConfig } from "@dimensionalpocket/dps-config";
 
-const config = new DpsConfig();
+// On Bun / Node.js
+const config = new DpsConfig(process.env);
 
 // defaults
 const domain = config.getDomain();
@@ -83,7 +84,7 @@ const authApiUrl = config.getAuthApiUrl();
 console.log(`Auth API URL: ${authApiUrl}`);
 
 // Vite support (loads environment variables with VITE_ prefix)
-const viteConfig = new DpsConfig("VITE_");
+const viteConfig = new DpsConfig(import.meta.env, "VITE_");
 ```
 
 ## Configuration Properties
@@ -95,6 +96,7 @@ Each property has a getter (`get_<property_name>()`) and a setter (`set_<propert
 
 | Property | Environment Variable | Default | Description |
 |----------|----------------------|---------|-------------|
+| `project_name` | `DPS_PROJECT_NAME` | `My Project` | Name of the project |
 | `domain` | `DPS_DOMAIN` | `dps.localhost` | Main domain of the website |
 | `api_path` | `DPS_API_PATH` | `api` | Path (without leading slash) for API endpoints |
 | `development_mode` | `DPS_DEVELOPMENT_MODE` | `false` | Enables development-only features |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ fn main() {
 
 ### Bun / TypeScript
 
+Note: The TypeScript constructor requires an environment object as its first argument, unlike the Rust version.
+
 ```typescript
 import { DpsConfig } from "@dimensionalpocket/dps-config";
 

--- a/docs/llm/plans/2026/04/10-update-readme-and-refactor-ts-env.md
+++ b/docs/llm/plans/2026/04/10-update-readme-and-refactor-ts-env.md
@@ -1,0 +1,45 @@
+# Plan: Update README and Refactor TS Env Loading
+
+Previously, "project name" was added to `DpsConfig` but not documented in `README.md`. Also, the TypeScript implementation needs to stop using `process.env` directly to support Vite apps.
+
+## User Requirements
+- Update `README.md` with `project_name`.
+- Change `DpsConfig` constructor in `src/index.ts` to `constructor(env: Record<string, string | undefined>, envPrefix: string = "")`.
+- `env` argument is required and has no default.
+- Store `env` in the instance (preferably a filtered subset for security).
+- Update `README.md` with the new constructor usage.
+- Discuss security: filtering `env` to only used keys.
+
+## Proposed Changes
+
+### 1. Update `README.md`
+- Add `project_name` to the Global configuration table.
+- Update Bun/TypeScript examples to show `new DpsConfig(process.env)` and `new DpsConfig(import.meta.env, 'VITE_')`.
+
+### 2. Modify `src/index.ts`
+- Define a constant or static property with all supported environment variable keys (without prefix).
+- Update the constructor to accept `env`.
+- Filter `env` to only include keys we care about.
+- Update `loadEnvString`, `loadEnvBool`, and `loadEnvNumber` to use the internal filtered env.
+
+### 3. Update `src/index.test.ts`
+- Pass an environment object to all `new DpsConfig()` calls.
+- Update tests to verify that it uses the passed object and not `process.env`.
+
+## Security Considerations
+By filtering the passed `env` object to only known keys (e.g., `DPS_DOMAIN`, `DPS_PROJECT_NAME`, etc.), we avoid storing sensitive unrelated environment variables (like `DATABASE_URL` or `SECRET_KEY` if they aren't part of `DpsConfig`) inside the config instance. This reduces the risk if the `DpsConfig` instance is ever serialized or inspected in a debugger.
+
+## Plan
+
+1. *Update `README.md` with `project_name` and new TypeScript constructor signature.*
+   - Add `project_name` to the table.
+   - Update examples.
+2. *Modify `src/index.ts` to implement the new constructor and filtered env storage.*
+   - Implement filtering logic.
+   - Update helper methods.
+3. *Update `src/index.test.ts` to reflect the changes.*
+   - Fix all constructor calls.
+   - Add a test case for the filtering logic.
+4. *Complete pre-commit steps*
+   - Ensure proper testing, verification, review, and reflection are done.
+5. *Submit the changes.*

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,16 +2,8 @@ import { describe, it, expect, afterEach } from "bun:test";
 import { DpsConfig } from "./index";
 
 describe("DpsConfig", () => {
-  afterEach(() => {
-    // Clean up environment variables after each test
-    const keysToRemove = Object.keys(process.env).filter(key => key.startsWith("DPS_") || key.startsWith("VITE_DPS_"));
-    for (const key of keysToRemove) {
-      delete process.env[key];
-    }
-  });
-
   it("should have correct default values", () => {
-    const config = new DpsConfig();
+    const config = new DpsConfig({});
     expect(config.getProjectName()).toBe("My Project");
     expect(config.getDomain()).toBe("dps.localhost");
     expect(config.getApiPath()).toBe("api");
@@ -31,7 +23,7 @@ describe("DpsConfig", () => {
   });
 
   it("should work with setters", () => {
-    const config = new DpsConfig();
+    const config = new DpsConfig({});
     config.setProjectName("Custom Project");
     config.setDomain("example.com");
     config.setApiPath("v1");
@@ -48,7 +40,7 @@ describe("DpsConfig", () => {
   });
 
   it("should build auth API URL without port", () => {
-    const config = new DpsConfig();
+    const config = new DpsConfig({});
     config.setAuthApiProtocol("https");
     config.setAuthApiSubdomain("auth");
     config.setDomain("dps.localhost");
@@ -56,7 +48,7 @@ describe("DpsConfig", () => {
   });
 
   it("should build auth API URL with port", () => {
-    const config = new DpsConfig();
+    const config = new DpsConfig({});
     config.setAuthApiProtocol("http");
     config.setAuthApiPort(3000);
     config.setAuthApiSubdomain("auth");
@@ -65,7 +57,7 @@ describe("DpsConfig", () => {
   });
 
   it("should follow README example", () => {
-    const config = new DpsConfig();
+    const config = new DpsConfig({});
     config.setDomain("test.local");
     config.setAuthApiProtocol("http");
     config.setAuthApiPort(8080);
@@ -73,35 +65,35 @@ describe("DpsConfig", () => {
   });
 
   it("should load insecure cookie setting from env", () => {
-    const c1 = new DpsConfig();
+    const c1 = new DpsConfig({});
     expect(c1.getAuthApiInsecureCookie()).toBe(false);
     c1.setAuthApiInsecureCookie(true);
     expect(c1.getAuthApiInsecureCookie()).toBe(true);
 
-    process.env.DPS_AUTH_API_INSECURE_COOKIE = "Y";
-    const c2 = new DpsConfig();
+    const c2 = new DpsConfig({ DPS_AUTH_API_INSECURE_COOKIE: "Y" });
     expect(c2.getAuthApiInsecureCookie()).toBe(true);
   });
 
   it("should load SQLite pool sizes from env", () => {
-    process.env.DPS_AUTH_API_SQLITE_MAIN_POOL_SIZE = "8";
-    process.env.DPS_AUTH_API_SQLITE_COLLECTION_POOL_SIZE = "4";
-    process.env.DPS_AUTH_API_SQLITE_SESSION_POOL_SIZE = "2";
-
-    const config = new DpsConfig();
+    const config = new DpsConfig({
+      DPS_AUTH_API_SQLITE_MAIN_POOL_SIZE: "8",
+      DPS_AUTH_API_SQLITE_COLLECTION_POOL_SIZE: "4",
+      DPS_AUTH_API_SQLITE_SESSION_POOL_SIZE: "2",
+    });
     expect(config.getAuthApiSqliteMainPoolSize()).toBe(8);
     expect(config.getAuthApiSqliteCollectionPoolSize()).toBe(4);
     expect(config.getAuthApiSqliteSessionPoolSize()).toBe(2);
   });
 
   it("should load SQLite file paths from env", () => {
-    process.env.DPS_AUTH_API_SQLITE_MAIN_FILE_PATH = "data/test-main.db";
-    const config = new DpsConfig();
+    const config = new DpsConfig({
+      DPS_AUTH_API_SQLITE_MAIN_FILE_PATH: "data/test-main.db",
+    });
     expect(config.getAuthApiSqliteMainFilePath()).toBe("data/test-main.db");
   });
 
   it("should return session secret bytes", () => {
-    const config = new DpsConfig();
+    const config = new DpsConfig({});
     config.setAuthApiSessionSecret("my-secret-key");
     const bytes = config.getAuthApiSessionSecretBytes();
     expect(bytes).toBeDefined();
@@ -109,31 +101,43 @@ describe("DpsConfig", () => {
   });
 
   it("should load session TTL from env", () => {
-    process.env.DPS_AUTH_API_SESSION_TTL_SECONDS = "1800";
-    const config = new DpsConfig();
+    const config = new DpsConfig({ DPS_AUTH_API_SESSION_TTL_SECONDS: "1800" });
     expect(config.getAuthApiSessionTtlSeconds()).toBe(1800);
   });
 
   it("should load API path from env", () => {
-    process.env.DPS_API_PATH = "api/v2";
-    const config = new DpsConfig();
+    const config = new DpsConfig({ DPS_API_PATH: "api/v2" });
     expect(config.getApiPath()).toBe("api/v2");
   });
 
   it("should load project name from env", () => {
-    process.env.DPS_PROJECT_NAME = "Env Project";
-    const config = new DpsConfig();
+    const config = new DpsConfig({ DPS_PROJECT_NAME: "Env Project" });
     expect(config.getProjectName()).toBe("Env Project");
   });
 
   it("should support envPrefix", () => {
-    process.env.VITE_DPS_DOMAIN = "vite.local";
-    process.env.DPS_DOMAIN = "standard.local";
+    const env = {
+      VITE_DPS_DOMAIN: "vite.local",
+      DPS_DOMAIN: "standard.local",
+    };
 
-    const config = new DpsConfig("VITE_");
+    const config = new DpsConfig(env, "VITE_");
     expect(config.getDomain()).toBe("vite.local");
 
-    const standardConfig = new DpsConfig();
+    const standardConfig = new DpsConfig(env);
     expect(standardConfig.getDomain()).toBe("standard.local");
+  });
+
+  it("should only store known environment variables", () => {
+    const env = {
+      DPS_DOMAIN: "example.com",
+      SECRET_KEY: "super-secret",
+    };
+    const config = new DpsConfig(env);
+
+    // @ts-ignore - accessing private field for testing
+    expect(config.env["DPS_DOMAIN"]).toBe("example.com");
+    // @ts-ignore - accessing private field for testing
+    expect(config.env["SECRET_KEY"]).toBeUndefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,29 @@
  * It focuses on optional values, sensible defaults, and environment variable loading.
  */
 export class DpsConfig {
+  /**
+   * List of supported environment variable keys (without prefix).
+   */
+  static readonly ENV_KEYS = [
+    "DPS_PROJECT_NAME",
+    "DPS_DOMAIN",
+    "DPS_API_PATH",
+    "DPS_DEVELOPMENT_MODE",
+    "DPS_AUTH_API_SUBDOMAIN",
+    "DPS_AUTH_API_PORT",
+    "DPS_AUTH_API_PROTOCOL",
+    "DPS_AUTH_API_INSECURE_COOKIE",
+    "DPS_AUTH_API_SQLITE_MAIN_FILE_PATH",
+    "DPS_AUTH_API_SQLITE_MAIN_POOL_SIZE",
+    "DPS_AUTH_API_SQLITE_COLLECTION_FILE_PATH",
+    "DPS_AUTH_API_SQLITE_COLLECTION_POOL_SIZE",
+    "DPS_AUTH_API_SQLITE_SESSION_FILE_PATH",
+    "DPS_AUTH_API_SQLITE_SESSION_POOL_SIZE",
+    "DPS_AUTH_API_SESSION_SECRET",
+    "DPS_AUTH_API_SESSION_TTL_SECONDS",
+  ] as const;
+
+  private env: Record<string, string | undefined>;
   private projectName?: string;
   private domain?: string;
   private apiPath?: string;
@@ -26,9 +49,18 @@ export class DpsConfig {
   /**
    * Create a new DpsConfig instance, loading values from environment variables when present.
    *
+   * @param env Environment variables object (e.g. process.env or import.meta.env).
    * @param envPrefix Optional prefix for environment variables (e.g. "VITE_" for Vite support).
    */
-  constructor(envPrefix: string = "") {
+  constructor(env: Record<string, string | undefined>, envPrefix: string = "") {
+    this.env = {};
+    for (const key of DpsConfig.ENV_KEYS) {
+      const fullKey = envPrefix + key;
+      if (env[fullKey] !== undefined) {
+        this.env[fullKey] = env[fullKey];
+      }
+    }
+
     this.projectName = this.loadEnvString(envPrefix, "DPS_PROJECT_NAME");
     this.domain = this.loadEnvString(envPrefix, "DPS_DOMAIN");
     this.apiPath = this.loadEnvString(envPrefix, "DPS_API_PATH");
@@ -213,17 +245,17 @@ export class DpsConfig {
   // --------------------
 
   private loadEnvString(prefix: string, key: string): string | undefined {
-    const value = process.env[prefix + key];
+    const value = this.env[prefix + key];
     return (value && value.length > 0) ? value : undefined;
   }
 
   private loadEnvBool(prefix: string, key: string): boolean | undefined {
-    const value = process.env[prefix + key];
+    const value = this.env[prefix + key];
     return value === "Y" ? true : (value === undefined ? undefined : false);
   }
 
   private loadEnvNumber(prefix: string, key: string): number | undefined {
-    const value = process.env[prefix + key];
+    const value = this.env[prefix + key];
     if (value === undefined || value.length === 0) {
       return undefined;
     }


### PR DESCRIPTION
This PR updates the `README.md` to document the previously added `project_name` configuration and introduces a significant refactor to the TypeScript implementation of `DpsConfig`.

The `DpsConfig` constructor now requires an environment object (e.g., `process.env` in Node/Bun or `import.meta.env` in Vite) as its first argument. This change removes the dependency on the global `process` object, making the package compatible with non-Node environments like Vite.

Additionally, for improved security, the `DpsConfig` instance now filters and stores only the environment variables it actually uses, preventing the accidental exposure or leakage of sensitive, unrelated environment variables.

Tests and documentation have been updated to reflect these changes.

---
*PR created automatically by Jules for task [10261963100264376172](https://jules.google.com/task/10261963100264376172) started by @pauldps*